### PR TITLE
Remove test container data recursively

### DIFF
--- a/tests/TestContainerRemover.php
+++ b/tests/TestContainerRemover.php
@@ -3,6 +3,10 @@ declare(strict_types=1);
 
 namespace Lcobucci\DependencyInjection\Behat\Tests;
 
+use function dirname;
+use function file_exists;
+use function is_dir;
+
 final class TestContainerRemover
 {
     public static function remove(): void
@@ -13,10 +17,20 @@ final class TestContainerRemover
             return;
         }
 
-        foreach (glob($tempDir . '/*') as $file) {
-            unlink($file);
+        self::removeDir($tempDir);
+    }
+
+    private static function removeDir(string $dir): void
+    {
+        foreach (glob($dir . '/*') as $path) {
+            if (is_dir($path)) {
+                self::removeDir($path);
+                continue;
+            }
+
+            unlink($path);
         }
 
-        rmdir($tempDir);
+        rmdir($dir);
     }
 }


### PR DESCRIPTION
Now `lcobucci/di-builder` generates multiple files in PHP 7.2, which means that we cannot simply try to remove files.